### PR TITLE
feat: privmx connection wrapper

### DIFF
--- a/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
@@ -14,6 +14,7 @@ import {
   StoreEventsManager,
   ThreadEventsManager,
 } from './events';
+import { PublicConnection } from './PublicConnection';
 
 /**
  * @class PrivmxClient
@@ -60,7 +61,7 @@ export class PrivmxClient {
    * @constructor
    * @param {Connection} connection - The connection object.
    */
-  constructor(private connection: Connection) {}
+  public constructor(private connection: Connection) {}
 
   /**
    * @description Sets up the PrivMX endpoint if it hasn't been set up yet.
@@ -165,6 +166,26 @@ export class PrivmxClient {
     return new PrivmxClient(connection);
   }
 
+    /**
+   * Connects to the Platform backend as a guest user.
+   *
+   * @param {string} solutionId ID of the Solution
+   * @param {string} bridgeUrl the Bridge Server URL
+   *
+   * @returns {Promise<PublicConnection>} Promised instance of Connection
+   */
+  static async connectPublic(solutionId: string, bridgeUrl: string): Promise<PublicConnection>{
+    this.checkSetup();
+
+    const connection = await EndpointFactory.connectPublic(solutionId, bridgeUrl)
+
+    if(!connection){
+      throw new Error('ERROR: Could not connect to bridge');
+    }
+
+    return new PublicConnection(connection);
+  }
+
   /**
    * @description Gets the connection object.
    * @returns {Connection}
@@ -181,7 +202,7 @@ export class PrivmxClient {
    * @description Gets the Thread API.
    * @returns {Promise<ThreadApi>}
    */
-  public getThreadApi(): Promise<ThreadApi> {
+  public async getThreadApi(): Promise<ThreadApi> {
     if (!this.threadApi) {
       this.threadApi = (() => {
         const connection = this.getConnection();
@@ -195,7 +216,7 @@ export class PrivmxClient {
    * @description Gets the Store API.
    * @returns {Promise<StoreApi>}
    */
-  public getStoreApi(): Promise<StoreApi> {
+  public async getStoreApi(): Promise<StoreApi> {
     if (!this.storeApi) {
       this.storeApi = (async () => {
         const connection = this.getConnection();
@@ -209,7 +230,7 @@ export class PrivmxClient {
    * @description Gets the Inbox API.
    * @returns {Promise<InboxApi>}
    */
-  public getInboxApi(): Promise<InboxApi> {
+  public async getInboxApi(): Promise<InboxApi> {
     if (!this.inboxApi) {
       this.inboxApi = (async () => {
         const connection = this.getConnection();
@@ -312,8 +333,4 @@ export class PrivmxClient {
       console.error('Error during disconnection:', e);
     }
   }
-}
-
-async function test() {
-  await PrivmxClient.setup('/path/to/privmx/assets');
 }

--- a/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
@@ -1,278 +1,300 @@
 import {
-    Connection,
-    CryptoApi,
-    EndpointFactory,
-    EventQueue,
-    InboxApi,
-    StoreApi,
-    ThreadApi,
-  } from "../service";
-  import {
-    ConnectionEventsManager,
-    EventManager,
-    InboxEventsManager,
-    StoreEventsManager,
-    ThreadEventsManager,
-  } from "./events";
-  
+  Connection,
+  CryptoApi,
+  EndpointFactory,
+  EventQueue,
+  InboxApi,
+  StoreApi,
+  ThreadApi,
+} from '../service';
+import {
+  ConnectionEventsManager,
+  EventManager,
+  InboxEventsManager,
+  StoreEventsManager,
+  ThreadEventsManager,
+} from './events';
+
+/**
+ * @class PrivmxClient
+ * @classdesc A client for interacting with the PrivMX Endpoint API.
+ * @example
+ * // Initialize the PrivMX client
+ * await PrivmxClient.setup('/path/to/privmx/assets');
+ *
+ * // Connect to the PrivMX bridge
+ * const privateKey = 'your-private-key';
+ * const solutionId = 'your-solution-id';
+ * const contextId = 'your-context-id';
+ * const bridgeUrl = 'https://your-bridge-url.com';
+ * const client = await PrivmxClient.connect(privateKey, solutionId, bridgeUrl);
+ *
+ * // Get the Thread API and list threads
+ * const threadApi = await client.getThreadApi();
+ * const threads = await threadApi.listThreads(contextId, {
+ *    skip: 0,
+ *    limit: 100,
+ *    sort: 'desc'
+ * })
+ *
+ * // Disconnect when done
+ * await client.disconnect();
+ */
+export class PrivmxClient {
+  private static cryptoApi: Promise<CryptoApi> | null = null;
+  private static eventQueue: Promise<EventQueue> | null = null;
+  private static isSetup = false;
+  private static eventManager: Promise<EventManager> | null = null;
+
+  private threadApi: Promise<ThreadApi> | null = null;
+  private storeApi: Promise<StoreApi> | null = null;
+  private inboxApi: Promise<InboxApi> | null = null;
+
+  private connectionEventManager: Promise<ConnectionEventsManager> | null =
+    null;
+  private threadEventManager: Promise<ThreadEventsManager> | null = null;
+  private storeEventManager: Promise<StoreEventsManager> | null = null;
+  private inboxEventManager: Promise<InboxEventsManager> | null = null;
+
   /**
-   * @class PrivmxClient
-   * @classdesc A client for interacting with the PrivMX services.
+   * @constructor
+   * @param {Connection} connection - The connection object.
    */
-  export class PrivmxClient {
-    private static cryptoApi: Promise<CryptoApi> | null = null;
-    private static eventQueue: Promise<EventQueue> | null = null;
-    private static isSetup = false;
-    private static eventManager: Promise<EventManager> | null = null;
+  constructor(private connection: Connection) {}
 
-    private threadApi: Promise<ThreadApi> | null = null;
-    private storeApi: Promise<StoreApi> | null = null;
-    private inboxApi: Promise<InboxApi> | null = null;
+  /**
+   * @description Sets up the PrivMX endpoint if it hasn't been set up yet.
+   * @param {string} folderPath - The path to the folder where PrivMX assets are stored.
+   * @returns {Promise<void>}
+   */
 
-    private connectionEventManager: Promise<ConnectionEventsManager> | null =
-      null;
-    private threadEventManager: Promise<ThreadEventsManager> | null = null;
-    private storeEventManager: Promise<StoreEventsManager> | null = null;
-    private inboxEventManager: Promise<InboxEventsManager> | null = null;
-  
-    /**
-     * @constructor
-     * @param {Connection} connection - The connection object.
-     */
-    constructor(private connection: Connection) {}
-  
-    /**
-     * @description Sets up the PrivMX endpoint if it hasn't been set up yet.
-     * @param {string} folderPath - The path to the folder where PrivMX assets are stored.
-     * @returns {Promise<void>}
-     */
-  
-    public static async setup(folderPath: string): Promise<void> {
-      if (!PrivmxClient.isSetup) {
-        await EndpointFactory.setup(folderPath);
-        PrivmxClient.isSetup = true;
-      }
+  public static async setup(folderPath: string): Promise<void> {
+    if (!PrivmxClient.isSetup) {
+      await EndpointFactory.setup(folderPath);
+      PrivmxClient.isSetup = true;
     }
+  }
 
-    private static checkSetup(){
-      if(!this.isSetup){
-        throw new Error("Endpoint not initialized, use PrivMXClient.setup(folderPath).");
-
-      }
+  private static checkSetup() {
+    if (!this.isSetup) {
+      throw new Error(
+        'Endpoint not initialized, use PrivMXClient.setup(folderPath).'
+      );
     }
+  }
 
-    /**
-     * @description Gets the Crypto API.
-     * @returns {Promise<CryptoApi>}
-     */
-    public static async getCryptoApi(): Promise<CryptoApi> {
-      if(this.cryptoApi){
-        return this.cryptoApi;
-      }
-
-      this.checkSetup()
-
-      this.cryptoApi = (async () => {
-        return EndpointFactory.createCryptoApi();
-      })();
-      
+  /**
+   * @description Gets the Crypto API.
+   * @returns {Promise<CryptoApi>}
+   */
+  public static async getCryptoApi(): Promise<CryptoApi> {
+    if (this.cryptoApi) {
       return this.cryptoApi;
     }
-  
-    /**
-     * @description Gets the Event Queue.
-     * @returns {Promise<EventQueue>}
-     */
-    public static async getEventQueue(): Promise<EventQueue> {
-      if (this.eventQueue) {
-        return this.eventQueue;
-      }
 
-      this.checkSetup();
-  
-      this.eventQueue = (async () => {
-        return EndpointFactory.getEventQueue();
-      })();
-  
+    this.checkSetup();
+
+    this.cryptoApi = (async () => {
+      return EndpointFactory.createCryptoApi();
+    })();
+
+    return this.cryptoApi;
+  }
+
+  /**
+   * @description Gets the Event Queue.
+   * @returns {Promise<EventQueue>}
+   */
+  public static async getEventQueue(): Promise<EventQueue> {
+    if (this.eventQueue) {
       return this.eventQueue;
     }
-  
-    /**
-     * @description Gets the Event Manager.
-     * @returns {Promise<EventManager>}
-     */
-    public static async getEventManager(): Promise<EventManager> {
-      if (this.eventManager) {
-        return this.eventManager;
-      }
 
-      this.checkSetup();
+    this.checkSetup();
 
-      this.eventManager = (async () => {
-        const eventQueue = await PrivmxClient.getEventQueue();
-        return EventManager.startEventLoop(eventQueue);
-      })();
-  
-      return await this.eventManager;
-    }
-  
-    /**
-     * @description Connects to the PrivMX bridge.
-     * @param {string} privateKey user's private key
-     * @param {string} solutionId ID of the Solution
-     * @param {string} bridgeUrl the Bridge Server URL
-     * @returns {Promise<PrivmxClient>}
-     * @throws {Error} If the connection to the bridge fails.
-     */
-    static async connect(
-      privateKey: string,
-      solutionId: string,
-      bridgeUrl: string
-    ): Promise<PrivmxClient> {
-      this.checkSetup();
+    this.eventQueue = (async () => {
+      return EndpointFactory.getEventQueue();
+    })();
 
-      const connection = await EndpointFactory.connect(
-        privateKey,
-        solutionId,
-        bridgeUrl
-      );
-  
-      if (!connection) {
-        throw new Error("ERROR: Could not connect to bridge");
-      }
-      return new PrivmxClient(connection);
+    return this.eventQueue;
+  }
+
+  /**
+   * @description Gets the Event Manager.
+   * @returns {Promise<EventManager>}
+   */
+  public static async getEventManager(): Promise<EventManager> {
+    if (this.eventManager) {
+      return this.eventManager;
     }
-  
-    /**
-     * @description Gets the connection object.
-     * @returns {Connection}
-     * @throws {Error} If there is no active connection.
-     */
-    public getConnection(): Connection {
-      if (!this.connection) {
-        throw new Error("No active connection");
-      }
-      return this.connection;
+
+    this.checkSetup();
+
+    this.eventManager = (async () => {
+      const eventQueue = await PrivmxClient.getEventQueue();
+      return EventManager.startEventLoop(eventQueue);
+    })();
+
+    return await this.eventManager;
+  }
+
+  /**
+   * @description Connects to the PrivMX bridge.
+   * @param {string} privateKey user's private key
+   * @param {string} solutionId ID of the Solution
+   * @param {string} bridgeUrl the Bridge Server URL
+   * @returns {Promise<PrivmxClient>}
+   * @throws {Error} If the connection to the bridge fails.
+   */
+  static async connect(
+    privateKey: string,
+    solutionId: string,
+    bridgeUrl: string
+  ): Promise<PrivmxClient> {
+    this.checkSetup();
+
+    const connection = await EndpointFactory.connect(
+      privateKey,
+      solutionId,
+      bridgeUrl
+    );
+
+    if (!connection) {
+      throw new Error('ERROR: Could not connect to bridge');
     }
-  
-    /**
-     * @description Gets the Thread API.
-     * @returns {Promise<ThreadApi>}
-     */
-    public getThreadApi(): Promise<ThreadApi> {
-      if (!this.threadApi) {
-        this.threadApi = (() => {
-          const connection = this.getConnection();
-          return EndpointFactory.createThreadApi(connection);
-        })();
-      }
-      return this.threadApi;
+    return new PrivmxClient(connection);
+  }
+
+  /**
+   * @description Gets the connection object.
+   * @returns {Connection}
+   * @throws {Error} If there is no active connection.
+   */
+  public getConnection(): Connection {
+    if (!this.connection) {
+      throw new Error('No active connection');
     }
-  
-    /**
-     * @description Gets the Store API.
-     * @returns {Promise<StoreApi>}
-     */
-    public getStoreApi(): Promise<StoreApi> {
-      if (!this.storeApi) {
-        this.storeApi = (async () => {
-          const connection = this.getConnection();
-          return EndpointFactory.createStoreApi(connection);
-        })();
-      }
-      return this.storeApi;
-    }
-  
-    /**
-     * @description Gets the Inbox API.
-     * @returns {Promise<InboxApi>}
-     */
-    public getInboxApi(): Promise<InboxApi> {
-      if (!this.inboxApi) {
-        this.inboxApi = (async () => {
-          const connection = this.getConnection();
-          return EndpointFactory.createInboxApi(
-            connection,
-            await this.getThreadApi(),
-            await this.getStoreApi()
-          );
-        })();
-      }
-      return this.inboxApi;
-    }
-  
-    /**
-     * @description Gets the Connection Event Manager.
-     * @returns {Promise<ConnectionEventsManager>}
-     */
-    public async getConnectionEventManager(): Promise<ConnectionEventsManager> {
-      if (this.connectionEventManager) {
-        return this.connectionEventManager;
-      }
-  
-      this.connectionEventManager = (async () => {
-        const eventManager = await PrivmxClient.getEventManager();
+    return this.connection;
+  }
+
+  /**
+   * @description Gets the Thread API.
+   * @returns {Promise<ThreadApi>}
+   */
+  public getThreadApi(): Promise<ThreadApi> {
+    if (!this.threadApi) {
+      this.threadApi = (() => {
         const connection = this.getConnection();
-        const connectionId =
-          (await connection.getConnectionId()) as unknown as string;
-        return eventManager.getConnectionEventManager(connectionId);
+        return EndpointFactory.createThreadApi(connection);
       })();
-  
+    }
+    return this.threadApi;
+  }
+
+  /**
+   * @description Gets the Store API.
+   * @returns {Promise<StoreApi>}
+   */
+  public getStoreApi(): Promise<StoreApi> {
+    if (!this.storeApi) {
+      this.storeApi = (async () => {
+        const connection = this.getConnection();
+        return EndpointFactory.createStoreApi(connection);
+      })();
+    }
+    return this.storeApi;
+  }
+
+  /**
+   * @description Gets the Inbox API.
+   * @returns {Promise<InboxApi>}
+   */
+  public getInboxApi(): Promise<InboxApi> {
+    if (!this.inboxApi) {
+      this.inboxApi = (async () => {
+        const connection = this.getConnection();
+        return EndpointFactory.createInboxApi(
+          connection,
+          await this.getThreadApi(),
+          await this.getStoreApi()
+        );
+      })();
+    }
+    return this.inboxApi;
+  }
+
+  /**
+   * @description Gets the Connection Event Manager.
+   * @returns {Promise<ConnectionEventsManager>}
+   */
+  public async getConnectionEventManager(): Promise<ConnectionEventsManager> {
+    if (this.connectionEventManager) {
       return this.connectionEventManager;
     }
-  
-    /**
-     * @description Gets the Thread Event Manager.
-     * @returns {Promise<ThreadEventsManager>}
-     */
-    public async getThreadEventManager(): Promise<ThreadEventsManager> {
-      if (this.threadEventManager) {
-        return this.threadEventManager;
-      }
-  
-      this.threadEventManager = (async () => {
-        const eventManager = await PrivmxClient.getEventManager();
-        return eventManager.getThreadEventManager(await this.getThreadApi());
-      })();
-  
+
+    this.connectionEventManager = (async () => {
+      const eventManager = await PrivmxClient.getEventManager();
+      const connection = this.getConnection();
+      const connectionId =
+        (await connection.getConnectionId()) as unknown as string;
+      return eventManager.getConnectionEventManager(connectionId);
+    })();
+
+    return this.connectionEventManager;
+  }
+
+  /**
+   * @description Gets the Thread Event Manager.
+   * @returns {Promise<ThreadEventsManager>}
+   */
+  public async getThreadEventManager(): Promise<ThreadEventsManager> {
+    if (this.threadEventManager) {
       return this.threadEventManager;
     }
-  
-    /**
-     * @description Gets the Store Event Manager.
-     * @returns {Promise<StoreEventsManager>}
-     */
-    public async getStoreEventManager(): Promise<StoreEventsManager> {
-      if (this.storeEventManager) {
-        return this.storeEventManager;
-      }
-  
-      this.storeEventManager = (async () => {
-        const eventManager = await PrivmxClient.getEventManager();
-        return eventManager.getStoreEventManager(await this.getStoreApi());
-      })();
-  
+
+    this.threadEventManager = (async () => {
+      const eventManager = await PrivmxClient.getEventManager();
+      return eventManager.getThreadEventManager(await this.getThreadApi());
+    })();
+
+    return this.threadEventManager;
+  }
+
+  /**
+   * @description Gets the Store Event Manager.
+   * @returns {Promise<StoreEventsManager>}
+   */
+  public async getStoreEventManager(): Promise<StoreEventsManager> {
+    if (this.storeEventManager) {
       return this.storeEventManager;
     }
-  
-    /**
-     * @description Gets the Inbox Event Manager.
-     * @returns {Promise<InboxEventsManager>}
-     */
-    public async getInboxEventManager(): Promise<InboxEventsManager> {
-      if (this.inboxEventManager) {
-        return this.inboxEventManager;
-      }
-  
-      this.inboxEventManager = (async () => {
-        const eventManager = await PrivmxClient.getEventManager();
-        return eventManager.getInboxEventManager(await this.getInboxApi());
-      })();
-  
+
+    this.storeEventManager = (async () => {
+      const eventManager = await PrivmxClient.getEventManager();
+      return eventManager.getStoreEventManager(await this.getStoreApi());
+    })();
+
+    return this.storeEventManager;
+  }
+
+  /**
+   * @description Gets the Inbox Event Manager.
+   * @returns {Promise<InboxEventsManager>}
+   */
+  public async getInboxEventManager(): Promise<InboxEventsManager> {
+    if (this.inboxEventManager) {
       return this.inboxEventManager;
     }
 
-    /**
+    this.inboxEventManager = (async () => {
+      const eventManager = await PrivmxClient.getEventManager();
+      return eventManager.getInboxEventManager(await this.getInboxApi());
+    })();
+
+    return this.inboxEventManager;
+  }
+
+  /**
    * @description Disconnects from the PrivMX bridge.
    * @returns {Promise<void>}
    */
@@ -290,6 +312,8 @@ import {
       console.error('Error during disconnection:', e);
     }
   }
+}
 
-  }
-  
+async function test() {
+  await PrivmxClient.setup('/path/to/privmx/assets');
+}

--- a/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
@@ -61,7 +61,7 @@ export class PrivmxClient {
    * @constructor
    * @param {Connection} connection - The connection object.
    */
-  public constructor(private connection: Connection) {}
+  private constructor(private connection: Connection) {}
 
   /**
    * @description Sets up the PrivMX endpoint if it hasn't been set up yet.

--- a/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
@@ -28,10 +28,10 @@ import {
     private threadApi: Promise<ThreadApi> | null = null;
     private storeApi: Promise<StoreApi> | null = null;
     private inboxApi: Promise<InboxApi> | null = null;
-    
+
     private connectionEventManager: Promise<ConnectionEventsManager> | null =
       null;
-    private threadEventManger: Promise<ThreadEventsManager> | null = null;
+    private threadEventManager: Promise<ThreadEventsManager> | null = null;
     private storeEventManager: Promise<StoreEventsManager> | null = null;
     private inboxEventManager: Promise<InboxEventsManager> | null = null;
   
@@ -211,16 +211,16 @@ import {
      * @returns {Promise<ThreadEventsManager>}
      */
     public async getThreadEventManager(): Promise<ThreadEventsManager> {
-      if (this.threadEventManger) {
-        return this.threadEventManger;
+      if (this.threadEventManager) {
+        return this.threadEventManager;
       }
   
-      this.threadEventManger = (async () => {
+      this.threadEventManager = (async () => {
         const eventManager = await PrivmxClient.getEventManager();
         return eventManager.getThreadEventManager(await this.getThreadApi());
       })();
   
-      return this.threadEventManger;
+      return this.threadEventManager;
     }
   
     /**
@@ -256,5 +256,25 @@ import {
   
       return this.inboxEventManager;
     }
+
+    /**
+   * @description Disconnects from the PrivMX bridge.
+   * @returns {Promise<void>}
+   */
+  public async disconnect(): Promise<void> {
+    try {
+      await this.connection.disconnect();
+      this.threadApi = null;
+      this.storeApi = null;
+      this.inboxApi = null;
+      this.connectionEventManager = null;
+      this.threadEventManager = null;
+      this.storeEventManager = null;
+      this.inboxEventManager = null;
+    } catch (e) {
+      console.error('Error during disconnection:', e);
+    }
+  }
+
   }
   

--- a/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PrivmxClient.ts
@@ -1,0 +1,260 @@
+import {
+    Connection,
+    CryptoApi,
+    EndpointFactory,
+    EventQueue,
+    InboxApi,
+    StoreApi,
+    ThreadApi,
+  } from "../service";
+  import {
+    ConnectionEventsManager,
+    EventManager,
+    InboxEventsManager,
+    StoreEventsManager,
+    ThreadEventsManager,
+  } from "./events";
+  
+  /**
+   * @class PrivmxClient
+   * @classdesc A client for interacting with the PrivMX services.
+   */
+  export class PrivmxClient {
+    private static cryptoApi: Promise<CryptoApi> | null = null;
+    private static eventQueue: Promise<EventQueue> | null = null;
+    private static isSetup = false;
+    private static eventManager: Promise<EventManager> | null = null;
+
+    private threadApi: Promise<ThreadApi> | null = null;
+    private storeApi: Promise<StoreApi> | null = null;
+    private inboxApi: Promise<InboxApi> | null = null;
+    
+    private connectionEventManager: Promise<ConnectionEventsManager> | null =
+      null;
+    private threadEventManger: Promise<ThreadEventsManager> | null = null;
+    private storeEventManager: Promise<StoreEventsManager> | null = null;
+    private inboxEventManager: Promise<InboxEventsManager> | null = null;
+  
+    /**
+     * @constructor
+     * @param {Connection} connection - The connection object.
+     */
+    constructor(private connection: Connection) {}
+  
+    /**
+     * @description Sets up the PrivMX endpoint if it hasn't been set up yet.
+     * @returns {Promise<void>}
+     */
+    private static async setup(): Promise<void> {
+      if (!PrivmxClient.isSetup) {
+        await EndpointFactory.setup("/privmx-assets");
+        PrivmxClient.isSetup = true;
+      }
+    }
+  
+    /**
+     * @description Gets the Crypto API.
+     * @returns {Promise<CryptoApi>}
+     */
+    public static async getCryptoApi(): Promise<CryptoApi> {
+      if (!this.cryptoApi) {
+        this.cryptoApi = (async () => {
+          await PrivmxClient.setup();
+          return EndpointFactory.createCryptoApi();
+        })();
+      }
+      return this.cryptoApi;
+    }
+  
+    /**
+     * @description Gets the Event Queue.
+     * @returns {Promise<EventQueue>}
+     */
+    public static async getEventQueue(): Promise<EventQueue> {
+      if (this.eventQueue) {
+        return this.eventQueue;
+      }
+  
+      if (!PrivmxClient.isSetup) {
+        await PrivmxClient.setup();
+      }
+      this.eventQueue = (async () => {
+        return EndpointFactory.getEventQueue();
+      })();
+  
+      return this.eventQueue;
+    }
+  
+    /**
+     * @description Gets the Event Manager.
+     * @returns {Promise<EventManager>}
+     */
+    public static async getEventManager(): Promise<EventManager> {
+      if (this.eventManager) {
+        return this.eventManager;
+      }
+  
+      this.eventManager = (async () => {
+        const eventQueue = await PrivmxClient.getEventQueue();
+        return EventManager.startEventLoop(eventQueue);
+      })();
+  
+      return await this.eventManager;
+    }
+  
+    /**
+     * @description Connects to the PrivMX bridge.
+     * @param {string} privateKey user's private key
+     * @param {string} solutionId ID of the Solution
+     * @param {string} bridgeUrl the Bridge Server URL
+     * @returns {Promise<PrivmxClient>}
+     * @throws {Error} If the connection to the bridge fails.
+     */
+    static async connect(
+      privateKey: string,
+      solutionId: string,
+      bridgeUrl: string
+    ): Promise<PrivmxClient> {
+      await PrivmxClient.setup();
+      const connection = await EndpointFactory.connect(
+        privateKey,
+        solutionId,
+        bridgeUrl
+      );
+  
+      if (!connection) {
+        throw new Error("ERROR: Could not connect to bridge");
+      }
+      return new PrivmxClient(connection);
+    }
+  
+    /**
+     * @description Gets the connection object.
+     * @returns {Connection}
+     * @throws {Error} If there is no active connection.
+     */
+    public getConnection(): Connection {
+      if (!this.connection) {
+        throw new Error("No active connection");
+      }
+      return this.connection;
+    }
+  
+    /**
+     * @description Gets the Thread API.
+     * @returns {Promise<ThreadApi>}
+     */
+    public getThreadApi(): Promise<ThreadApi> {
+      if (!this.threadApi) {
+        this.threadApi = (() => {
+          const connection = this.getConnection();
+          return EndpointFactory.createThreadApi(connection);
+        })();
+      }
+      return this.threadApi;
+    }
+  
+    /**
+     * @description Gets the Store API.
+     * @returns {Promise<StoreApi>}
+     */
+    public getStoreApi(): Promise<StoreApi> {
+      if (!this.storeApi) {
+        this.storeApi = (async () => {
+          const connection = this.getConnection();
+          return EndpointFactory.createStoreApi(connection);
+        })();
+      }
+      return this.storeApi;
+    }
+  
+    /**
+     * @description Gets the Inbox API.
+     * @returns {Promise<InboxApi>}
+     */
+    public getInboxApi(): Promise<InboxApi> {
+      if (!this.inboxApi) {
+        this.inboxApi = (async () => {
+          const connection = this.getConnection();
+          return EndpointFactory.createInboxApi(
+            connection,
+            await this.getThreadApi(),
+            await this.getStoreApi()
+          );
+        })();
+      }
+      return this.inboxApi;
+    }
+  
+    /**
+     * @description Gets the Connection Event Manager.
+     * @returns {Promise<ConnectionEventsManager>}
+     */
+    public async getConnectionEventManager(): Promise<ConnectionEventsManager> {
+      if (this.connectionEventManager) {
+        return this.connectionEventManager;
+      }
+  
+      this.connectionEventManager = (async () => {
+        const eventManager = await PrivmxClient.getEventManager();
+        const connection = this.getConnection();
+        const connectionId =
+          (await connection.getConnectionId()) as unknown as string;
+        return eventManager.getConnectionEventManager(connectionId);
+      })();
+  
+      return this.connectionEventManager;
+    }
+  
+    /**
+     * @description Gets the Thread Event Manager.
+     * @returns {Promise<ThreadEventsManager>}
+     */
+    public async getThreadEventManager(): Promise<ThreadEventsManager> {
+      if (this.threadEventManger) {
+        return this.threadEventManger;
+      }
+  
+      this.threadEventManger = (async () => {
+        const eventManager = await PrivmxClient.getEventManager();
+        return eventManager.getThreadEventManager(await this.getThreadApi());
+      })();
+  
+      return this.threadEventManger;
+    }
+  
+    /**
+     * @description Gets the Store Event Manager.
+     * @returns {Promise<StoreEventsManager>}
+     */
+    public async getStoreEventManager(): Promise<StoreEventsManager> {
+      if (this.storeEventManager) {
+        return this.storeEventManager;
+      }
+  
+      this.storeEventManager = (async () => {
+        const eventManager = await PrivmxClient.getEventManager();
+        return eventManager.getStoreEventManager(await this.getStoreApi());
+      })();
+  
+      return this.storeEventManager;
+    }
+  
+    /**
+     * @description Gets the Inbox Event Manager.
+     * @returns {Promise<InboxEventsManager>}
+     */
+    public async getInboxEventManager(): Promise<InboxEventsManager> {
+      if (this.inboxEventManager) {
+        return this.inboxEventManager;
+      }
+  
+      this.inboxEventManager = (async () => {
+        const eventManager = await PrivmxClient.getEventManager();
+        return eventManager.getInboxEventManager(await this.getInboxApi());
+      })();
+  
+      return this.inboxEventManager;
+    }
+  }
+  

--- a/privmx-webendpoint-api/ts/src/extra/PublicConnection.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PublicConnection.ts
@@ -42,7 +42,7 @@ export class PublicConnection {
    * @constructor
    * @param {Connection} connection - The connection object.
    */
-  public constructor(private connection: Connection) {}
+  constructor(private connection: Connection) {}
 
 
   /**

--- a/privmx-webendpoint-api/ts/src/extra/PublicConnection.ts
+++ b/privmx-webendpoint-api/ts/src/extra/PublicConnection.ts
@@ -1,0 +1,131 @@
+import { Inboxes } from '.';
+import {
+  Connection,
+  EndpointFactory,
+  InboxApi,
+  StoreApi,
+  ThreadApi,
+} from '../service';
+
+import { InboxEntryPayload } from './inbox';
+
+/**
+ * @class PublicConnection
+ * @classdesc A client for interacting with the PrivMX Endpoint API as a guest. The scope is limited to sending an entries to inboxes.
+ * @example
+ * // Initialize the PrivMX client
+ * await PrivmxClient.setup('/path/to/privmx/assets');
+ *
+ * // Connect to the PrivMX bridge
+ * const solutionId = 'your-solution-id';
+ * const bridgeUrl = 'https://your-bridge-url.com';
+ * const inboxId = 'your-inbox-id'
+ * const client = await PrivmxClient.connectPublic(solutionId, bridgeUrl);
+ *
+ * // Send entry
+ * const encoder = new TextEncoder();
+ * const encodedData = encoder.encode(JSON.stringify({ message: 'Hello, PrivMX!' }));
+ * 
+ * await client.sendEntry(inboxId, {
+ *  data: encodedData
+ * })
+ *
+ * // Disconnect when done
+ * await client.disconnect();
+ */
+export class PublicConnection {
+  private threadApi: Promise<ThreadApi> | null = null;
+  private storeApi: Promise<StoreApi> | null = null;
+  private inboxApi: Promise<InboxApi> | null = null;
+
+  /**
+   * @constructor
+   * @param {Connection} connection - The connection object.
+   */
+  public constructor(private connection: Connection) {}
+
+
+  /**
+   * @description Gets the connection object.
+   * @returns {Connection}
+   * @throws {Error} If there is no active connection.
+   */
+  private getConnection(): Connection {
+    if (!this.connection) {
+      throw new Error('No active connection');
+    }
+    return this.connection;
+  }
+
+  /**
+   * @description Gets the Thread API.
+   * @returns {Promise<ThreadApi>}
+   */
+  private getThreadApi(): Promise<ThreadApi> {
+    if (!this.threadApi) {
+      this.threadApi = (() => {
+        const connection = this.getConnection();
+        return EndpointFactory.createThreadApi(connection);
+      })();
+    }
+    return this.threadApi;
+  }
+
+  /**
+   * @description Gets the Store API.
+   * @returns {Promise<StoreApi>}
+   */
+  private getStoreApi(): Promise<StoreApi> {
+    if (!this.storeApi) {
+      this.storeApi = (async () => {
+        const connection = this.getConnection();
+        return EndpointFactory.createStoreApi(connection);
+      })();
+    }
+    return this.storeApi;
+  }
+
+  /**
+   * @description Gets the Inbox API.
+   * @returns {Promise<InboxApi>}
+   */
+  private getInboxApi(): Promise<InboxApi> {
+    if (!this.inboxApi) {
+      this.inboxApi = (async () => {
+        const connection = this.getConnection();
+        return EndpointFactory.createInboxApi(
+          connection,
+          await this.getThreadApi(),
+          await this.getStoreApi()
+        );
+      })();
+    }
+    return this.inboxApi;
+  }
+
+  /**
+   * @description Disconnects from the PrivMX bridge.
+   * @returns {Promise<void>}
+   */
+  public async disconnect(): Promise<void> {
+    try {
+      await this.connection.disconnect();
+      this.threadApi = null;
+      this.storeApi = null;
+      this.inboxApi = null;
+    } catch (e) {
+      console.error('Error during disconnection:', e);
+    }
+  }
+
+  /**
+   * @description Sends an entry to the specified inbox.
+   * @param {string} inboxId - The ID of the inbox to send the entry to.
+   * @param {InboxEntryPayload} payload - The payload of the entry to send.
+   * @returns {Promise<void>}
+   */
+  public async sendEntry(inboxId: string, payload: InboxEntryPayload): Promise<void>{
+    const inboxApi = await this.getInboxApi();
+    return await Inboxes.sendEntry(inboxApi, inboxId, payload);
+  }
+}

--- a/privmx-webendpoint-api/ts/src/extra/inbox.ts
+++ b/privmx-webendpoint-api/ts/src/extra/inbox.ts
@@ -1,4 +1,4 @@
-import { Endpoint } from '..';
+import { InboxApi } from '..';
 import { FileUploader } from './files';
 
 /**
@@ -34,7 +34,7 @@ export interface InboxEntryPayload {
 /**
  * Sends an entry to the specified inbox.
  *
- * @param {Awaited<ReturnType<typeof Endpoint.createInboxApi>>} inboxApi - The API instance used to interact with the inbox.
+ * @param {InboxApi} inboxApi - The API instance used to interact with the inbox.
  * @param {string} inboxId - The ID of the target inbox where the entry will be sent.
  * @param {InboxEntryPayload} payload - The data payload for the inbox entry, including files, metadata, and other information.
  *
@@ -42,7 +42,7 @@ export interface InboxEntryPayload {
  *
  */
 export async function sendEntry(
-    inboxApi: Awaited<ReturnType<typeof Endpoint.createInboxApi>>,
+    inboxApi: InboxApi,
     inboxId: string,
     payload: InboxEntryPayload
 ): Promise<void> {

--- a/privmx-webendpoint-api/ts/src/extra/index.ts
+++ b/privmx-webendpoint-api/ts/src/extra/index.ts
@@ -17,6 +17,7 @@ import * as Inboxes from './inbox';
 
 import { FileUploader, StreamReader, downloadFile } from './files';
 import { PrivmxClient } from './PrivmxClient';
+import { PublicConnection } from './PublicConnection';
 
 export {
   Files,
@@ -33,6 +34,7 @@ export {
   BaseEventManager,
   StreamReader,
   PrivmxClient,
+  PublicConnection,
   Channel,
   ConnectionEventsManager,
   EventPayload,

--- a/privmx-webendpoint-api/ts/src/extra/index.ts
+++ b/privmx-webendpoint-api/ts/src/extra/index.ts
@@ -1,28 +1,40 @@
-import * as Files from "./files";
-import * as Events from "./events";
-import { EventManager, ThreadEventsManager, StoreEventsManager, InboxEventsManager, BaseEventManager, ConnectionEventsManager,  Channel, EventPayload, GenericEvent  } from "./events";
-import * as Utils from "./utils";
-import * as Generics from "./generics";
-import * as Inboxes from "./inbox";
+import * as Files from './files';
+import * as Events from './events';
+import {
+  EventManager,
+  ThreadEventsManager,
+  StoreEventsManager,
+  InboxEventsManager,
+  BaseEventManager,
+  ConnectionEventsManager,
+  Channel,
+  EventPayload,
+  GenericEvent,
+} from './events';
+import * as Utils from './utils';
+import * as Generics from './generics';
+import * as Inboxes from './inbox';
 
-import { FileUploader, StreamReader, downloadFile } from "./files";
+import { FileUploader, StreamReader, downloadFile } from './files';
+import { PrivmxClient } from './PrivmxClient';
 
 export {
-    Files, 
-    Inboxes, 
-    Events, 
-    Utils, 
-    Generics, 
-    FileUploader,
-    downloadFile,
-    EventManager, 
-    ThreadEventsManager, 
-    StoreEventsManager, 
-    InboxEventsManager, 
-    BaseEventManager, 
-    StreamReader,
-    Channel, 
-    ConnectionEventsManager,
-    EventPayload,
-    GenericEvent
+  Files,
+  Inboxes,
+  Events,
+  Utils,
+  Generics,
+  FileUploader,
+  downloadFile,
+  EventManager,
+  ThreadEventsManager,
+  StoreEventsManager,
+  InboxEventsManager,
+  BaseEventManager,
+  StreamReader,
+  PrivmxClient,
+  Channel,
+  ConnectionEventsManager,
+  EventPayload,
+  GenericEvent,
 };


### PR DESCRIPTION
- Added PrivmxClient class -  wrapper that streamlines managing API instances and event handlers per connection. 
- Added PublicConnection class - wrapper when connecting with `connectPublic` - limits the scope to `sendEntry()` and `disconnect`
- Small fix with types  