### PR TITLE
fix(webrtc-lifecycle): session-scoped KeyStore, destroyRefs teardown, worker fix

### DIFF
--- a/src/native/ConnectionNative.ts
+++ b/src/native/ConnectionNative.ts
@@ -38,9 +38,6 @@ export class ConnectionNative extends BaseNative {
         return ++this.verifierBindingId;
     }
 
-    protected async newApi(_connectionPtr: number): Promise<number> {
-        throw new Error("Use the newConnection() - specialized version of method instead.");
-    }
     async deleteApi(ptr: number): Promise<void> {
         await this.runAsync<void>((taskId) =>
             this.api.lib.Connection_deleteConnection(taskId, ptr),

--- a/src/native/EventQueueNative.ts
+++ b/src/native/EventQueueNative.ts
@@ -13,9 +13,6 @@ import { Event } from "../Types";
 import { BaseNative } from "./BaseNative";
 
 export class EventQueueNative extends BaseNative {
-    protected async newApi(_connectionPtr: number): Promise<number> {
-        throw new Error("Use the newEventQueue() - specialized version of method instead.");
-    }
     async deleteApi(ptr: number): Promise<void> {
         await this.runAsync<void>((taskId) =>
             this.api.lib.EventQueue_deleteEventQueue(taskId, ptr),

--- a/src/native/ExtKeyNative.ts
+++ b/src/native/ExtKeyNative.ts
@@ -29,11 +29,13 @@ export class ExtKeyNative extends BaseNative {
     }
 
     async derive(ptr: number, args: [number]): Promise<ExtKeyNativePtr> {
+        // index: number
         return this.runAsync<ExtKeyNativePtr>((taskId) =>
             this.api.lib.ExtKey_derive(taskId, ptr, args),
         );
     }
     async deriveHardened(ptr: number, args: [number]): Promise<ExtKeyNativePtr> {
+        // index: number
         return this.runAsync<ExtKeyNativePtr>((taskId) =>
             this.api.lib.ExtKey_deriveHardened(taskId, ptr, args),
         );
@@ -82,6 +84,7 @@ export class ExtKeyNative extends BaseNative {
     }
 
     verifyCompactSignatureWithHash(ptr: number, args: [Uint8Array, Uint8Array]): Promise<boolean> {
+        // message: Uint8Array, signature: Uint8Array
         return this.runAsync<boolean>((taskId) =>
             this.api.lib.ExtKey_verifyCompactSignatureWithHash(taskId, ptr, args),
         );

--- a/src/native/StreamApiNative.ts
+++ b/src/native/StreamApiNative.ts
@@ -110,6 +110,9 @@ export class StreamApiNative extends BaseNative {
         );
     }
     async createStream(ptr: number, args: [string]): Promise<Types.StreamHandle> {
+        // params from api: streamRoomId, streamId
+        // params to lib: streamRoomId, streamId, webrtcInterfacePtr
+        // const libArgs: [string, number, number] = [...args, this.webRtcInterfacePtr];
         return this.runAsync<Types.StreamHandle>((taskId) =>
             this.api.lib.StreamApi_createStream(taskId, ptr, args),
         );

--- a/src/service/BaseApi.ts
+++ b/src/service/BaseApi.ts
@@ -9,8 +9,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { BaseNative } from "../native/BaseNative";
-
 export class BaseApi {
     private _servicePtr: number;
 

--- a/src/service/EventQueue.ts
+++ b/src/service/EventQueue.ts
@@ -14,7 +14,7 @@ import { EventQueueNative } from "../native/EventQueueNative";
 import { Event } from "../Types";
 
 export class EventQueue extends BaseApi {
-    private deferedPromise: Promise<Event>;
+    private deferedPromise: Promise<Event> | null = null;
     constructor(
         private native: EventQueueNative,
         ptr: number,

--- a/src/service/StreamApi.ts
+++ b/src/service/StreamApi.ts
@@ -3,7 +3,6 @@ import { AudioLevelsStats, WebRtcClient } from "../webStreams/WebRtcClient";
 import {
     Stream,
     StreamCreateMeta,
-    StreamRoomId,
     StreamTrack,
     StreamTrackId,
     StreamTrackInit,
@@ -37,9 +36,13 @@ export class StreamApi extends BaseApi {
         super(ptr);
     }
 
-    // local data
     private streams: Map<StreamHandle, Stream> = new Map();
-    private streamTracks: Map<string, StreamTrack> = new Map();
+    private streamTracks: Map<StreamTrackId, StreamTrack> = new Map();
+
+    public override destroyRefs(): void {
+        this.client.destroy();
+        super.destroyRefs();
+    }
 
     /**
      * Creates a new Stream Room in given Context.
@@ -59,7 +62,7 @@ export class StreamApi extends BaseApi {
         publicMeta: Uint8Array,
         privateMeta: Uint8Array,
         policies?: ContainerPolicy,
-    ): Promise<StreamRoomId> {
+    ): Promise<EndpointTypes.StreamRoomId> {
         const res = await this.native.createStreamRoom(this.servicePtr, [
             contextId,
             users,
@@ -68,7 +71,7 @@ export class StreamApi extends BaseApi {
             privateMeta,
             policies,
         ]);
-        return res as StreamRoomId;
+        return res as EndpointTypes.StreamRoomId;
     }
 
     /**
@@ -85,7 +88,7 @@ export class StreamApi extends BaseApi {
      * @param {ContainerPolicy} policies Stream Room's policies (pass `undefined` to keep current/defaults)
      */
     public async updateStreamRoom(
-        streamRoomId: StreamRoomId,
+        streamRoomId: EndpointTypes.StreamRoomId,
         users: UserWithPubKey[],
         managers: UserWithPubKey[],
         publicMeta: Uint8Array,
@@ -130,7 +133,7 @@ export class StreamApi extends BaseApi {
      *
      * @param {string} streamRoomId ID of the Stream Room to join
      */
-    public async joinStreamRoom(streamRoomId: StreamRoomId): Promise<void> {
+    public async joinStreamRoom(streamRoomId: EndpointTypes.StreamRoomId): Promise<void> {
         return this.native.joinStreamRoom(this.servicePtr, [streamRoomId]);
     }
 
@@ -139,7 +142,7 @@ export class StreamApi extends BaseApi {
      *
      * @param {string} streamRoomId ID of the Stream Room to leave
      */
-    public async leaveStreamRoom(streamRoomId: StreamRoomId): Promise<void> {
+    public async leaveStreamRoom(streamRoomId: EndpointTypes.StreamRoomId): Promise<void> {
         return this.native.leaveStreamRoom(this.servicePtr, [streamRoomId]);
     }
 
@@ -148,7 +151,9 @@ export class StreamApi extends BaseApi {
      *
      * @param {string} streamRoomId ID of the Stream Room
      */
-    public async enableStreamRoomRecording(streamRoomId: StreamRoomId): Promise<void> {
+    public async enableStreamRoomRecording(
+        streamRoomId: EndpointTypes.StreamRoomId,
+    ): Promise<void> {
         return this.native.enableStreamRoomRecording(this.servicePtr, [streamRoomId]);
     }
 
@@ -156,10 +161,10 @@ export class StreamApi extends BaseApi {
      * Gets encryption keys used for Stream Room recordings.
      *
      * @param {string} streamRoomId ID of the Stream Room
-     * @returns {EndpointTypes.RecordingEncKey[]} list of recording encryption keys
+     * @returns {EndpointRecordingEncKey[]} list of recording encryption keys
      */
     public async getStreamRoomRecordingKeys(
-        streamRoomId: StreamRoomId,
+        streamRoomId: EndpointTypes.StreamRoomId,
     ): Promise<EndpointTypes.RecordingEncKey[]> {
         return this.native.getStreamRoomRecordingKeys(this.servicePtr, [streamRoomId]);
     }
@@ -170,7 +175,7 @@ export class StreamApi extends BaseApi {
      * @param {string} streamRoomId ID of the Stream Room to get
      * @returns {StreamRoom} information about the Stream Room
      */
-    public async getStreamRoom(streamRoomId: StreamRoomId): Promise<StreamRoom> {
+    public async getStreamRoom(streamRoomId: EndpointTypes.StreamRoomId): Promise<StreamRoom> {
         return this.native.getStreamRoom(this.servicePtr, [streamRoomId]);
     }
 
@@ -179,7 +184,7 @@ export class StreamApi extends BaseApi {
      *
      * @param {string} streamRoomId ID of the Stream Room to delete
      */
-    public async deleteStreamRoom(streamRoomId: StreamRoomId): Promise<void> {
+    public async deleteStreamRoom(streamRoomId: EndpointTypes.StreamRoomId): Promise<void> {
         return this.native.deleteStreamRoom(this.servicePtr, [streamRoomId]);
     }
 
@@ -192,10 +197,8 @@ export class StreamApi extends BaseApi {
      * @param {string} streamRoomId ID of the Stream Room to create the stream in
      * @returns {StreamHandle} handle to a local Stream instance
      */
-    public async createStream(streamRoomId: StreamRoomId): Promise<StreamHandle> {
+    public async createStream(streamRoomId: EndpointTypes.StreamRoomId): Promise<StreamHandle> {
         const meta: StreamCreateMeta = {};
-        // tutaj uzupelniajac opcjonalne pola obiektu meta mozemy ustawiac w Janusie dodatkowe rzeczy
-
         const handle = await this.native.createStream(this.servicePtr, [streamRoomId]);
         this.streams.set(handle, { handle, streamRoomId, createStreamMeta: meta, remote: false });
         return handle;
@@ -207,9 +210,8 @@ export class StreamApi extends BaseApi {
      * @param {string} streamRoomId ID of the Stream Room to list streams from
      * @returns {StreamInfo[]} list of StreamInfo structs describing currently published streams
      */
-    public async listStreams(streamRoomId: StreamRoomId): Promise<StreamInfo[]> {
-        const remoteStreams = await this.native.listStreams(this.servicePtr, [streamRoomId]);
-        return remoteStreams;
+    public async listStreams(streamRoomId: EndpointTypes.StreamRoomId): Promise<StreamInfo[]> {
+        return this.native.listStreams(this.servicePtr, [streamRoomId]);
     }
 
     /**
@@ -226,47 +228,36 @@ export class StreamApi extends BaseApi {
         streamHandle: StreamHandle,
         meta: StreamTrackInit,
     ): Promise<StreamTrackId> {
-        if (!this.streams.has(streamHandle)) {
+        const stream = this.streams.get(streamHandle);
+        if (!stream) {
             throw new Error("[addStreamTrack]: there is no Stream with given Id: " + streamHandle);
         }
 
-        let alreadyAddedId = "";
-
-        const tracksByHandle = Array.from(this.streamTracks.values()).filter(
-            (x) => x.streamHandle === streamHandle,
-        );
-
-        for (const streamTrack of tracksByHandle) {
-            if (streamTrack.track && streamTrack.track.id === meta.track?.id) {
-                if (streamTrack.markedToRemove === true) {
-                    streamTrack.markedToRemove = undefined;
-                    alreadyAddedId = streamTrack.id;
-                    break;
-                } else {
-                    throw new Error(
-                        "[addStreamTrack] StreamTrack with given browser's track already added.",
-                    );
-                }
+        // If this browser track was previously staged and then marked for removal, un-remove it.
+        for (const streamTrack of this.streamTracks.values()) {
+            if (
+                streamTrack.streamHandle !== streamHandle ||
+                streamTrack.track?.id !== meta.track?.id
+            ) {
+                continue;
             }
-        }
-
-        if (alreadyAddedId.length > 0) {
-            return alreadyAddedId as StreamTrackId;
-        }
-        const stream = this.streams.get(streamHandle);
-        if (!stream) {
-            throw new Error("Cannot find stream by id");
+            if (streamTrack.markedToRemove) {
+                streamTrack.markedToRemove = undefined;
+                return streamTrack.id;
+            }
+            throw new Error(
+                "[addStreamTrack] StreamTrack with given browser's track already added.",
+            );
         }
 
         const streamTrackId = crypto.randomUUID() as StreamTrackId;
-        const streamTrack: StreamTrack = {
+        this.streamTracks.set(streamTrackId, {
             id: streamTrackId,
-            streamHandle: streamHandle,
+            streamHandle,
             track: meta.track,
             dataChannelMeta: { created: meta.createDataChannel },
             published: false,
-        };
-        this.streamTracks.set(streamTrackId, streamTrack);
+        });
         return streamTrackId;
     }
 
@@ -288,9 +279,8 @@ export class StreamApi extends BaseApi {
                 "[removeStreamTrack]: there is no Stream with given Id: " + streamHandle,
             );
         }
-        for (const [key, streamTrack] of this.streamTracks.entries()) {
+        for (const streamTrack of this.streamTracks.values()) {
             if (
-                streamTrack.track &&
                 streamTrack.track?.id === meta.track?.id &&
                 streamTrack.streamHandle === streamHandle
             ) {
@@ -311,60 +301,41 @@ export class StreamApi extends BaseApi {
         streamHandle: StreamHandle,
         onStreamState?: (state: RTCPeerConnectionState) => void,
     ): Promise<StreamPublishResult> {
-        const mediaTracks: MediaStreamTrack[] = [];
-        const dataTracks: StreamTrack[] = [];
-
-        for (const value of this.streamTracks.values()) {
-            let toPublish = false;
-            if (
-                value.streamHandle === streamHandle &&
-                value.track &&
-                !value.markedToRemove &&
-                value.published === false
-            ) {
-                mediaTracks.push(value.track);
-                // value.published = true;
-                toPublish = true;
-            }
-
-            if (
-                value.streamHandle === streamHandle &&
-                value.dataChannelMeta.created === true &&
-                !value.markedToRemove &&
-                value.published === false
-            ) {
-                dataTracks.push(value);
-                toPublish = true;
-            }
-            value.published = toPublish;
-        }
-        const _stream = this.streams.get(streamHandle);
-        if (!_stream) {
+        const stream = this.streams.get(streamHandle);
+        if (!stream) {
             throw new Error("No stream defined to publish");
         }
 
-        _stream.localMediaStream =
-            mediaTracks.length > 0 ? new MediaStream(mediaTracks) : undefined;
+        const mediaTracks: MediaStreamTrack[] = [];
+        const dataTracks: StreamTrack[] = [];
+
+        for (const track of this.streamTracks.values()) {
+            if (track.streamHandle !== streamHandle || track.markedToRemove || track.published) {
+                continue;
+            }
+            if (track.track) mediaTracks.push(track.track);
+            if (track.dataChannelMeta.created) dataTracks.push(track);
+            track.published = true;
+        }
+
+        stream.localMediaStream = mediaTracks.length > 0 ? new MediaStream(mediaTracks) : undefined;
 
         const turnCredentials = await this.native.getTurnCredentials(this.servicePtr, []);
         await this.client.setTurnCredentials(turnCredentials);
         await this.client.createPeerConnectionWithLocalStream(
             streamHandle,
-            _stream.streamRoomId,
-            _stream.localMediaStream,
+            stream.streamRoomId,
+            stream.localMediaStream,
             dataTracks,
         );
 
-        if (onStreamState && typeof onStreamState === "function") {
+        if (onStreamState) {
             this.client
                 .getStreamStateChangeDispatcher()
-                .addOnStateChangeListener({ streamHandle: streamHandle }, (event) =>
-                    onStreamState(event.state),
-                );
+                .addOnStateChangeListener({ streamHandle }, (event) => onStreamState(event.state));
         }
 
-        const res = await this.native.publishStream(this.servicePtr, [streamHandle]);
-        return res;
+        return this.native.publishStream(this.servicePtr, [streamHandle]);
     }
 
     /**
@@ -375,49 +346,29 @@ export class StreamApi extends BaseApi {
      * @throws {Error} when the given `streamHandle` does not exist
      */
     public async updateStream(streamHandle: StreamHandle): Promise<StreamPublishResult> {
-        // configure client
+        const stream = this.streams.get(streamHandle);
+        if (!stream) {
+            throw new Error("No stream defined to publish");
+        }
+
         const tracksToAdd: MediaStreamTrack[] = [];
         const tracksToRemove: MediaStreamTrack[] = [];
-        for (const value of this.streamTracks.values()) {
-            if (value.streamHandle === streamHandle && value.track) {
-                if (!value.published && !value.markedToRemove) {
-                    tracksToAdd.push(value.track);
-                }
-                if (value.markedToRemove) {
-                    tracksToRemove.push(value.track);
-                }
-            }
-        }
-        const _stream = this.streams.get(streamHandle);
-        if (!_stream) {
-            throw new Error("No stream defined to publish");
+
+        for (const track of this.streamTracks.values()) {
+            if (track.streamHandle !== streamHandle || !track.track) continue;
+            if (!track.published && !track.markedToRemove) tracksToAdd.push(track.track);
+            if (track.markedToRemove) tracksToRemove.push(track.track);
         }
 
         const turnCredentials = await this.native.getTurnCredentials(this.servicePtr, []);
         await this.client.setTurnCredentials(turnCredentials);
         await this.client.updatePeerConnectionWithLocalStream(
-            _stream.streamRoomId,
-            _stream.localMediaStream,
+            stream.streamRoomId,
+            stream.localMediaStream,
             tracksToAdd,
             tracksToRemove,
         );
-        const res = await this.native.updateStream(this.servicePtr, [streamHandle]);
-        return res;
-    }
-
-    private filterMapByValue<K, V>(
-        map: Map<K, V>,
-        predicate: (value: V, key: K) => boolean,
-    ): Map<K, V> {
-        const result = new Map<K, V>();
-
-        for (const [key, value] of map) {
-            if (predicate(value, key)) {
-                result.set(key, value);
-            }
-        }
-
-        return result;
+        return this.native.updateStream(this.servicePtr, [streamHandle]);
     }
 
     /**
@@ -427,21 +378,19 @@ export class StreamApi extends BaseApi {
      * @throws {Error} when the given `streamHandle` does not exist
      */
     public async unpublishStream(streamHandle: StreamHandle): Promise<void> {
-        if (!this.streams.has(streamHandle)) {
+        const stream = this.streams.get(streamHandle);
+        if (!stream) {
             throw new Error("No local stream with given id to unpublish");
         }
-        const _stream = this.streams.get(streamHandle);
 
-        const filteredTracks = this.filterMapByValue(
-            this.streamTracks,
-            (x) => x.streamHandle !== streamHandle,
-        );
-        this.streamTracks = filteredTracks;
+        for (const [id, track] of this.streamTracks) {
+            if (track.streamHandle === streamHandle) this.streamTracks.delete(id);
+        }
 
         await this.native.unpublishStream(this.servicePtr, [streamHandle]);
         this.client.removeSenderPeerConnectionOnUnpublish(
-            _stream.streamRoomId,
-            _stream.localMediaStream,
+            stream.streamRoomId,
+            stream.localMediaStream,
         );
         this.streams.delete(streamHandle);
         this.client.getStreamStateChangeDispatcher().removeOnStateChangeListener({ streamHandle });
@@ -451,17 +400,14 @@ export class StreamApi extends BaseApi {
      * Subscribes to selected remote streams (and optionally specific tracks) in the Stream Room.
      *
      * @param {string} streamRoomId ID of the Stream Room
-     * @param {EndpointTypes.StreamSubscription[]} subscriptions list of remote streams/tracks to subscribe to
+     * @param {StreamSubscription[]} subscriptions list of remote streams/tracks to subscribe to
      */
     async subscribeToRemoteStreams(
-        streamRoomId: StreamRoomId,
-        subscriptions: EndpointTypes.StreamSubscription[],
+        streamRoomId: EndpointTypes.StreamRoomId,
+        subscriptions: StreamSubscription[],
     ): Promise<void> {
-        // native part
         const peerCredentials = await this.native.getTurnCredentials(this.servicePtr, []);
         await this.client.setTurnCredentials(peerCredentials);
-
-        // server / core part
         await this.native.subscribeToRemoteStreams(this.servicePtr, [streamRoomId, subscriptions]);
         this.client.initializeSubscriberConnection(streamRoomId);
     }
@@ -470,15 +416,15 @@ export class StreamApi extends BaseApi {
      * Modifies current remote streams subscriptions.
      *
      * @param {string} streamRoomId ID of the Stream Room
-     * @param {EndpointTypes.StreamSubscription[]} subscriptionsToAdd list of subscriptions to add
+     * @param {StreamSubscription[]} subscriptionsToAdd list of subscriptions to add
      * @param {StreamSubscription[]} subscriptionsToRemove list of subscriptions to remove
      */
     async modifyRemoteStreamsSubscriptions(
-        streamRoomId: StreamRoomId,
-        subscriptionsToAdd: EndpointTypes.StreamSubscription[],
+        streamRoomId: EndpointTypes.StreamRoomId,
+        subscriptionsToAdd: StreamSubscription[],
         subscriptionsToRemove: StreamSubscription[],
     ): Promise<void> {
-        await this.native.modifyRemoteStreamsSubscriptions(this.servicePtr, [
+        return this.native.modifyRemoteStreamsSubscriptions(this.servicePtr, [
             streamRoomId,
             subscriptionsToAdd,
             subscriptionsToRemove,
@@ -492,10 +438,10 @@ export class StreamApi extends BaseApi {
      * @param {StreamSubscription[]} subscriptions list of subscriptions to remove
      */
     async unsubscribeFromRemoteStreams(
-        streamRoomId: StreamRoomId,
+        streamRoomId: EndpointTypes.StreamRoomId,
         subscriptions: StreamSubscription[],
     ): Promise<void> {
-        await this.native.unsubscribeFromRemoteStreams(this.servicePtr, [
+        return this.native.unsubscribeFromRemoteStreams(this.servicePtr, [
             streamRoomId,
             subscriptions,
         ]);
@@ -509,7 +455,7 @@ export class StreamApi extends BaseApi {
      * @param {number} [listener.streamId] optional remote Stream ID to filter events (omit for all streams)
      * @param {(event: RTCTrackEvent) => void} listener.onRemoteStreamTrack callback invoked for incoming remote tracks
      */
-    addRemoteStreamListener(listener: RemoteStreamListener) {
+    addRemoteStreamListener(listener: RemoteStreamListener): void {
         this.client.addRemoteStreamListener(listener);
     }
 
@@ -517,7 +463,7 @@ export class StreamApi extends BaseApi {
      * Subscribe for the Stream Room events on the given subscription query.
      *
      * @param {string[]} subscriptionQueries list of queries
-     * @return list of subscriptionIds in maching order to subscriptionQueries
+     * @return list of subscriptionIds in matching order to subscriptionQueries
      */
     async subscribeFor(subscriptionQueries: string[]): Promise<string[]> {
         return this.native.subscribeFor(this.servicePtr, [subscriptionQueries]);
@@ -554,10 +500,8 @@ export class StreamApi extends BaseApi {
      *
      * @param {(stats: AudioLevelsStats) => void} onStats callback invoked with current audio levels stats
      */
-    async addAudioLevelStatsListener(onStats: (stats: AudioLevelsStats) => void) {
-        if (onStats && typeof onStats === "function") {
-            this.client.setAudioLevelCallback(onStats);
-        }
+    async addAudioLevelStatsListener(onStats: (stats: AudioLevelsStats) => void): Promise<void> {
+        this.client.setAudioLevelCallback(onStats);
     }
 
     /**
@@ -567,12 +511,12 @@ export class StreamApi extends BaseApi {
      * @param {Uint8Array} data bytes to send to remote participants
      * @throws {Error} when there is no DataTrack (or DataChannel) for the given `streamTrackId`
      */
-    async sendData(streamTrackId: StreamTrackId, data: Uint8Array) {
+    async sendData(streamTrackId: StreamTrackId, data: Uint8Array): Promise<void> {
         const dataChannel = this.streamTracks.get(streamTrackId)?.dataChannelMeta.dataChannel;
         if (!dataChannel) {
             throw new Error(`There is no DataTrack with given streamTrackId: ${streamTrackId}`);
         }
         const frame = await this.client.encryptDataChannelData(data);
-        dataChannel.send(frame);
+        dataChannel.send(new Uint8Array(frame));
     }
 }

--- a/src/webStreams/KeyStore.ts
+++ b/src/webStreams/KeyStore.ts
@@ -3,60 +3,87 @@ import { CryptoFacade } from "../crypto/CryptoFacade";
 
 const AES_GCM_KEY_LENGTH_BYTES = 32;
 
+/**
+ * Owns the set of AES-256-GCM keys for a single WebRTC session.
+ *
+ * Keys are registered in the global CryptoFacade registry under a
+ * session-scoped internal ID (`<sessionPrefix>:<externalKeyId>`) to
+ * prevent cross-session collisions when the server reuses key IDs.
+ *
+ * Callers work exclusively with the external key IDs (as they appear on
+ * the wire). `resolveKeyId()` translates to the internal registry key.
+ */
 export class KeyStore {
-    private readonly registeredKeyIds = new Set<string>();
-    private encryptionKeyId: string | undefined = undefined;
+    private readonly sessionPrefix: string;
+    private readonly externalToInternal = new Map<string, string>();
+    private encryptionInternalKeyId: string | undefined = undefined;
+
+    constructor() {
+        this.sessionPrefix = crypto.randomUUID();
+    }
 
     async setKeys(keys: Key[]): Promise<void> {
-        for (const id of this.registeredKeyIds) {
-            CryptoFacade.unregisterKey(id);
+        for (const internalId of this.externalToInternal.values()) {
+            CryptoFacade.unregisterKey(internalId);
         }
-        this.registeredKeyIds.clear();
-        this.encryptionKeyId = undefined;
+        this.externalToInternal.clear();
+        this.encryptionInternalKeyId = undefined;
+
         for (const k of keys) {
             const rawKey = new Uint8Array(k.key);
             if (rawKey.length !== AES_GCM_KEY_LENGTH_BYTES) {
                 throw new Error(`Invalid key length: ${rawKey.length}`);
             }
+            const internalId = `${this.sessionPrefix}:${k.keyId}`;
             await CryptoFacade.importKeyAndWipeMaterial(
                 rawKey,
                 { name: "AES-GCM" },
                 ["encrypt", "decrypt"],
-                k.keyId,
+                internalId,
             );
-            this.registeredKeyIds.add(k.keyId);
+            this.externalToInternal.set(k.keyId, internalId);
             if (k.type === 0) {
-                this.encryptionKeyId = k.keyId;
+                this.encryptionInternalKeyId = internalId;
             }
         }
     }
 
-    hasKey(keyId: string): boolean {
-        return this.registeredKeyIds.has(keyId);
-    }
-
-    getEncryptionKeyId(): string {
-        if (!this.encryptionKeyId) {
-            throw new Error("No encryption key set.");
-        }
-        return this.encryptionKeyId;
+    hasKey(externalKeyId: string): boolean {
+        return this.externalToInternal.has(externalKeyId);
     }
 
     /**
-     * Returns the wire-format key ID to embed in outgoing frames.
-     * In this implementation the internal and wire IDs are identical;
-     * a future refactor will introduce a session-scoped prefix.
-     */
-    getEncryptionExternalKeyId(): string {
-        return this.getEncryptionKeyId();
-    }
-
-    /**
-     * Translates a wire-format key ID to the internal CryptoFacade registry ID.
-     * In this implementation they are identical; a session-prefix refactor will
-     * override this mapping.
+     * Returns the internal CryptoFacade key ID for the given external (wire) key ID.
+     * Throws if the key is not registered.
      */
     resolveKeyId(externalKeyId: string): string {
-        return externalKeyId;
+        const internal = this.externalToInternal.get(externalKeyId);
+        if (!internal) throw new Error(`Key not found: ${externalKeyId}`);
+        return internal;
+    }
+
+    /**
+     * Returns the internal CryptoFacade key ID for the active encryption key.
+     * Pass this to CryptoFacade encrypt/decrypt calls.
+     * Throws if no encryption key has been set.
+     */
+    getEncryptionKeyId(): string {
+        if (!this.encryptionInternalKeyId) {
+            throw new Error("No encryption key set.");
+        }
+        return this.encryptionInternalKeyId;
+    }
+
+    /**
+     * Returns the external (wire-format) key ID for the active encryption key.
+     * Write this value into the wire frame so the peer can look it up.
+     * Throws if no encryption key has been set.
+     */
+    getEncryptionExternalKeyId(): string {
+        if (!this.encryptionInternalKeyId) {
+            throw new Error("No encryption key set.");
+        }
+        // Strip the session prefix to recover the original external key ID.
+        return this.encryptionInternalKeyId.slice(this.sessionPrefix.length + 1);
     }
 }

--- a/src/webStreams/__tests__/AudioManager.test.ts
+++ b/src/webStreams/__tests__/AudioManager.test.ts
@@ -1,0 +1,204 @@
+import { AudioManager } from "../AudioManager";
+import { LOCAL_PUBLISHER_ID } from "../audio/ActiveSpeakerDetector";
+import { LocalAudioLevelMeter } from "../audio/LocalAudioLevelMeter";
+
+// ---- minimal browser-API stubs needed by AudioManager ----
+
+class FakeAudioWorkletNode {
+    port = { onmessage: null as ((ev: MessageEvent) => void) | null };
+    connect() {}
+    disconnect() {}
+}
+
+class FakeGainNode {
+    gain = { value: 1 };
+    connect() {}
+    disconnect() {}
+}
+
+class FakeMediaStreamAudioSourceNode {
+    connect() {}
+    disconnect() {}
+}
+
+class FakeAudioContext {
+    destination = {};
+    audioWorklet = {
+        addModule: jest.fn().mockResolvedValue(undefined),
+    };
+    resume = jest.fn().mockResolvedValue(undefined);
+    close = jest.fn();
+    createGain() {
+        return new FakeGainNode();
+    }
+    createMediaStreamSource() {
+        return new FakeMediaStreamAudioSourceNode();
+    }
+}
+
+interface BrowserGlobals {
+    AudioContext: typeof FakeAudioContext;
+    AudioWorkletNode: typeof FakeAudioWorkletNode;
+}
+
+const g = global as unknown as BrowserGlobals;
+g.AudioContext = FakeAudioContext;
+g.AudioWorkletNode = FakeAudioWorkletNode;
+
+function makeTrack(id: string, kind: "audio" | "video" = "audio"): MediaStreamTrack {
+    return {
+        id,
+        kind,
+        enabled: true,
+        getSettings: () => ({}),
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+    } as unknown as MediaStreamTrack;
+}
+
+describe("AudioManager", () => {
+    let onRmsForWorker: jest.Mock;
+    let manager: AudioManager;
+
+    beforeEach(() => {
+        onRmsForWorker = jest.fn();
+        manager = new AudioManager("/assets", onRmsForWorker);
+    });
+
+    describe("setAudioLevelCallback", () => {
+        it("registers the callback so onRemoteFrameRms fires it", () => {
+            const cb = jest.fn();
+            manager.setAudioLevelCallback(cb);
+            manager.onRemoteFrameRms(42, 0.5);
+            expect(cb).toHaveBeenCalledTimes(1);
+            expect(cb.mock.calls[0][0]).toHaveProperty("levels");
+        });
+
+        it("does not fire the callback before it is registered", () => {
+            const cb = jest.fn();
+            manager.onRemoteFrameRms(1, 0.9); // no callback yet
+            manager.setAudioLevelCallback(cb);
+            expect(cb).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onRemoteFrameRms", () => {
+        it("passes RMS and publisherId to the active speaker detector", () => {
+            const cb = jest.fn();
+            manager.setAudioLevelCallback(cb);
+
+            manager.onRemoteFrameRms(7, 0.8);
+            const result = cb.mock.calls[0][0];
+            expect(result.levels.some((s: { streamId: number }) => s.streamId === 7)).toBe(true);
+        });
+
+        it("always feeds LOCAL_PUBLISHER_ID (local) into the detector before the remote frame", () => {
+            const cb = jest.fn();
+            manager.setAudioLevelCallback(cb);
+            manager.onRemoteFrameRms(5, 0.1);
+            const result = cb.mock.calls[0][0];
+            expect(
+                result.levels.some((s: { streamId: number }) => s.streamId === LOCAL_PUBLISHER_ID),
+            ).toBe(true);
+        });
+    });
+
+    describe("stopLocalAudioLevelMeter", () => {
+        it("is a no-op when no meter exists for the track", () => {
+            const track = makeTrack("no-such-meter");
+            expect(() => manager.stopLocalAudioLevelMeter(track)).not.toThrow();
+        });
+    });
+
+    describe("ensureLocalAudioLevelMeter", () => {
+        it("does not add a second meter for the same track", async () => {
+            const initSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "init")
+                .mockResolvedValue(undefined);
+
+            const track = makeTrack("track-1");
+            await manager.ensureLocalAudioLevelMeter(track);
+            await manager.ensureLocalAudioLevelMeter(track); // second call — same track
+
+            expect(initSpy).toHaveBeenCalledTimes(1);
+            initSpy.mockRestore();
+        });
+
+        it("removes the meter if init throws and allows retry", async () => {
+            const initSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "init")
+                .mockRejectedValue(new Error("worklet load failed"));
+            const stopSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "stop")
+                .mockReturnValue(undefined);
+
+            const track = makeTrack("track-err");
+            await expect(manager.ensureLocalAudioLevelMeter(track)).rejects.toThrow(
+                "worklet load failed",
+            );
+
+            initSpy.mockResolvedValue(undefined);
+            await expect(manager.ensureLocalAudioLevelMeter(track)).resolves.not.toThrow();
+            expect(initSpy).toHaveBeenCalledTimes(2);
+
+            initSpy.mockRestore();
+            stopSpy.mockRestore();
+        });
+
+        it("forwards enabled-track RMS to onRmsForWorker", async () => {
+            let capturedOnLevel: ((rms: number) => void) | undefined;
+
+            const initSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "init")
+                .mockImplementation(async function (this: LocalAudioLevelMeter) {
+                    capturedOnLevel = (this as unknown as { onLevel: (rms: number) => void })
+                        .onLevel;
+                });
+
+            const track = makeTrack("track-rms");
+            await manager.ensureLocalAudioLevelMeter(track);
+
+            capturedOnLevel!(0.75);
+            expect(onRmsForWorker).toHaveBeenCalledWith(0.75);
+            initSpy.mockRestore();
+        });
+
+        it("reports silence to worker when track is disabled", async () => {
+            let capturedOnLevel: ((rms: number) => void) | undefined;
+
+            const initSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "init")
+                .mockImplementation(async function (this: LocalAudioLevelMeter) {
+                    capturedOnLevel = (this as unknown as { onLevel: (rms: number) => void })
+                        .onLevel;
+                });
+
+            const track = makeTrack("track-muted");
+            Object.defineProperty(track, "enabled", { value: false, writable: false });
+            await manager.ensureLocalAudioLevelMeter(track);
+
+            capturedOnLevel!(0.9);
+            expect(onRmsForWorker).toHaveBeenCalledWith(LocalAudioLevelMeter.RMS_VALUE_OF_SILENCE);
+            initSpy.mockRestore();
+        });
+    });
+
+    describe("stopLocalAudioLevelMeter (after adding)", () => {
+        it("calls stop() on the meter and allows re-adding the same track", async () => {
+            const stopSpy = jest
+                .spyOn(LocalAudioLevelMeter.prototype, "stop")
+                .mockReturnValue(undefined);
+            jest.spyOn(LocalAudioLevelMeter.prototype, "init").mockResolvedValue(undefined);
+
+            const track = makeTrack("track-stop");
+            await manager.ensureLocalAudioLevelMeter(track);
+            manager.stopLocalAudioLevelMeter(track);
+            expect(stopSpy).toHaveBeenCalledTimes(1);
+
+            await manager.ensureLocalAudioLevelMeter(track);
+            expect(stopSpy).toHaveBeenCalledTimes(1); // stop not called again on re-add
+
+            stopSpy.mockRestore();
+        });
+    });
+});

--- a/src/webStreams/__tests__/E2eeTransformManager.test.ts
+++ b/src/webStreams/__tests__/E2eeTransformManager.test.ts
@@ -1,0 +1,230 @@
+import { E2eeTransformManager } from "../E2eeTransformManager";
+import { E2eeWorker } from "../E2eeWorker";
+import {
+    WindowWithRTCRtpScriptTransform,
+    RTCRtpReceiverWithTransform,
+    RTCRtpSenderWithTransform,
+} from "../types/WebRtcExtensions";
+
+// ---- window stub (Jest runs in node, not jsdom) ------------------------------
+
+let testWindow: WindowWithRTCRtpScriptTransform;
+
+function resetTestWindow(): void {
+    testWindow = {} as WindowWithRTCRtpScriptTransform;
+    (global as unknown as { window: WindowWithRTCRtpScriptTransform }).window = testWindow;
+}
+resetTestWindow();
+
+// ---- E2eeWorker mock --------------------------------------------------------
+
+function makeMockWorker(): jest.Mocked<E2eeWorker> {
+    return {
+        get: jest.fn().mockResolvedValue({ _fakeWorker: true }),
+        setKeys: jest.fn().mockResolvedValue(undefined),
+        sendRms: jest.fn().mockResolvedValue(undefined),
+        postEncode: jest.fn().mockResolvedValue(undefined),
+        postDecode: jest.fn().mockResolvedValue(undefined),
+        postStop: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<E2eeWorker>;
+}
+
+// ---- RTCRtp stubs -----------------------------------------------------------
+
+function makeSender(): RTCRtpSenderWithTransform {
+    return {
+        transform: undefined,
+        createEncodedStreams: jest.fn().mockReturnValue({
+            readable: { _type: "readable" },
+            writable: { _type: "writable" },
+        }),
+    } as unknown as RTCRtpSenderWithTransform;
+}
+
+function makeReceiver(trackId = "track-1"): RTCRtpReceiverWithTransform {
+    return {
+        track: { id: trackId },
+        transform: undefined,
+        createEncodedStreams: jest.fn().mockReturnValue({
+            readable: { _type: "readable" },
+            writable: { _type: "writable" },
+        }),
+    } as unknown as RTCRtpReceiverWithTransform;
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("E2eeTransformManager", () => {
+    let worker: jest.Mocked<E2eeWorker>;
+    let manager: E2eeTransformManager;
+
+    beforeEach(() => {
+        resetTestWindow();
+        worker = makeMockWorker();
+        manager = new E2eeTransformManager(worker);
+    });
+
+    // -------------------------------------------------------------------------
+    // setupSenderTransform
+    // -------------------------------------------------------------------------
+
+    describe("setupSenderTransform — RTCRtpScriptTransform available", () => {
+        beforeEach(() => {
+            testWindow.RTCRtpScriptTransform = jest
+                .fn()
+                .mockImplementation(() => ({ _isTransform: true }));
+        });
+
+        it("assigns a transform on the sender", async () => {
+            const sender = makeSender();
+            await manager.setupSenderTransform(sender);
+            expect(sender.transform).toBeDefined();
+        });
+
+        it("does NOT call createEncodedStreams", async () => {
+            const sender = makeSender();
+            await manager.setupSenderTransform(sender);
+            expect(sender.createEncodedStreams).not.toHaveBeenCalled();
+        });
+
+        it("calls e2eeWorker.get() to obtain the worker instance", async () => {
+            await manager.setupSenderTransform(makeSender());
+            expect(worker.get).toHaveBeenCalledTimes(1);
+        });
+
+        it("constructs RTCRtpScriptTransform with operation=encode", async () => {
+            await manager.setupSenderTransform(makeSender());
+            expect(testWindow.RTCRtpScriptTransform).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({ operation: "encode" }),
+            );
+        });
+    });
+
+    describe("setupSenderTransform — EncodedStreams fallback", () => {
+        it("calls createEncodedStreams and posts encode to worker", async () => {
+            const sender = makeSender();
+            const { readable, writable } = sender.createEncodedStreams();
+            (sender.createEncodedStreams as jest.Mock).mockClear();
+
+            await manager.setupSenderTransform(sender);
+
+            expect(sender.createEncodedStreams).toHaveBeenCalledTimes(1);
+            expect(worker.postEncode).toHaveBeenCalledWith(readable, writable);
+        });
+
+        it("does NOT assign sender.transform", async () => {
+            const sender = makeSender();
+            await manager.setupSenderTransform(sender);
+            expect(sender.transform).toBeUndefined();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // setupReceiverTransform
+    // -------------------------------------------------------------------------
+
+    describe("setupReceiverTransform — RTCRtpScriptTransform available", () => {
+        beforeEach(() => {
+            testWindow.RTCRtpScriptTransform = jest
+                .fn()
+                .mockImplementation(() => ({ _isTransform: true }));
+        });
+
+        it("assigns a transform on the receiver", async () => {
+            const receiver = makeReceiver("track-rx");
+            await manager.setupReceiverTransform(receiver, 5);
+            expect(receiver.transform).toBeDefined();
+        });
+
+        it("does NOT call createEncodedStreams", async () => {
+            const receiver = makeReceiver("track-rx");
+            await manager.setupReceiverTransform(receiver, 5);
+            expect(receiver.createEncodedStreams).not.toHaveBeenCalled();
+        });
+
+        it("constructs RTCRtpScriptTransform with operation=decode, correct id and publisherId", async () => {
+            const receiver = makeReceiver("track-rx-id");
+            await manager.setupReceiverTransform(receiver, 42);
+            expect(testWindow.RTCRtpScriptTransform).toHaveBeenCalledWith(
+                expect.anything(),
+                expect.objectContaining({
+                    operation: "decode",
+                    id: "track-rx-id",
+                    publisherId: 42,
+                }),
+            );
+        });
+
+        it("falls through to EncodedStreams when transform is already assigned", async () => {
+            const receiver = makeReceiver("track-already-transformed");
+            (receiver as any).transform = { _existing: true };
+
+            await manager.setupReceiverTransform(receiver, 1);
+
+            // RTCRtpScriptTransform constructor should not have been called
+            expect(testWindow.RTCRtpScriptTransform).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("setupReceiverTransform — EncodedStreams fallback", () => {
+        it("calls createEncodedStreams and posts decode to worker", async () => {
+            const receiver = makeReceiver("track-enc");
+            await manager.setupReceiverTransform(receiver, 99);
+
+            expect(receiver.createEncodedStreams).toHaveBeenCalledTimes(1);
+            expect(worker.postDecode).toHaveBeenCalledWith(
+                "track-enc",
+                99,
+                expect.anything(),
+                expect.anything(),
+            );
+        });
+
+        it("does not call createEncodedStreams a second time for the same receiver", async () => {
+            const receiver = makeReceiver("track-dedup-enc");
+            await manager.setupReceiverTransform(receiver, 1);
+            await manager.setupReceiverTransform(receiver, 1);
+
+            expect(receiver.createEncodedStreams).toHaveBeenCalledTimes(1);
+            expect(worker.postDecode).toHaveBeenCalledTimes(1);
+        });
+
+        it("is a no-op when createEncodedStreams is not a function", async () => {
+            const receiver = makeReceiver("track-no-api");
+            delete (receiver as any).createEncodedStreams;
+
+            await expect(manager.setupReceiverTransform(receiver, 1)).resolves.toBeUndefined();
+            expect(worker.postDecode).not.toHaveBeenCalled();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // teardownReceiver
+    // -------------------------------------------------------------------------
+
+    describe("teardownReceiver", () => {
+        it("posts a stop message for a receiver set up via EncodedStreams", async () => {
+            const receiver = makeReceiver("track-tear");
+            await manager.setupReceiverTransform(receiver, 7);
+            await manager.teardownReceiver(receiver);
+
+            expect(worker.postStop).toHaveBeenCalledWith("track-tear");
+        });
+
+        it("is a no-op for a receiver that was never set up", async () => {
+            const receiver = makeReceiver("unknown");
+            await expect(manager.teardownReceiver(receiver)).resolves.toBeUndefined();
+            expect(worker.postStop).not.toHaveBeenCalled();
+        });
+
+        it("removes the receiver from the registry so a second teardown is also a no-op", async () => {
+            const receiver = makeReceiver("track-double-tear");
+            await manager.setupReceiverTransform(receiver, 3);
+            await manager.teardownReceiver(receiver);
+            await manager.teardownReceiver(receiver);
+
+            expect(worker.postStop).toHaveBeenCalledTimes(1);
+        });
+    });
+});

--- a/src/webStreams/__tests__/RemoteStreamListenerRegistry.test.ts
+++ b/src/webStreams/__tests__/RemoteStreamListenerRegistry.test.ts
@@ -1,0 +1,160 @@
+import { RemoteStreamListenerRegistry } from "../RemoteStreamListenerRegistry";
+import { RemoteStreamListener } from "../../Types";
+import { StreamId, StreamRoomId } from "../types/ApiTypes";
+
+const ROOM = "room-1" as StreamRoomId;
+const ROOM_2 = "room-2" as StreamRoomId;
+
+function sid(n: number): StreamId {
+    return n as StreamId;
+}
+
+function makeTrackEvent(streamId: number): RTCTrackEvent {
+    return {
+        streams: [{ id: String(streamId) }],
+        track: {},
+        receiver: {},
+    } as unknown as RTCTrackEvent;
+}
+
+describe("RemoteStreamListenerRegistry", () => {
+    let registry: RemoteStreamListenerRegistry;
+
+    beforeEach(() => {
+        registry = new RemoteStreamListenerRegistry();
+    });
+
+    describe("add", () => {
+        it("adds a listener without throwing", () => {
+            const listener: RemoteStreamListener = { streamRoomId: ROOM, streamId: sid(1) };
+            expect(() => registry.add(listener)).not.toThrow();
+        });
+
+        it("allows listeners with different streamIds in the same room", () => {
+            registry.add({ streamRoomId: ROOM, streamId: sid(1) });
+            expect(() => registry.add({ streamRoomId: ROOM, streamId: sid(2) })).not.toThrow();
+        });
+
+        it("allows the same streamId in different rooms", () => {
+            registry.add({ streamRoomId: ROOM, streamId: sid(1) });
+            expect(() => registry.add({ streamRoomId: ROOM_2, streamId: sid(1) })).not.toThrow();
+        });
+
+        it("allows a wildcard listener (streamId undefined) alongside specific ones", () => {
+            registry.add({ streamRoomId: ROOM });
+            expect(() => registry.add({ streamRoomId: ROOM, streamId: sid(5) })).not.toThrow();
+        });
+
+        it("throws when adding a duplicate (same room + same streamId)", () => {
+            registry.add({ streamRoomId: ROOM, streamId: sid(3) });
+            expect(() => registry.add({ streamRoomId: ROOM, streamId: sid(3) })).toThrow(
+                "RemoteStreamListener with given params already exists.",
+            );
+        });
+
+        it("throws when adding a second wildcard listener in the same room", () => {
+            registry.add({ streamRoomId: ROOM });
+            expect(() => registry.add({ streamRoomId: ROOM })).toThrow(
+                "RemoteStreamListener with given params already exists.",
+            );
+        });
+    });
+
+    describe("dispatchTrack", () => {
+        it("calls onRemoteStreamTrack on matching listener", () => {
+            const onTrack = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(10), onRemoteStreamTrack: onTrack });
+            const event = makeTrackEvent(10);
+            registry.dispatchTrack(ROOM, event);
+            expect(onTrack).toHaveBeenCalledWith(event);
+        });
+
+        it("does not call listener registered for a different streamId", () => {
+            const onTrack = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(10), onRemoteStreamTrack: onTrack });
+            registry.dispatchTrack(ROOM, makeTrackEvent(99));
+            expect(onTrack).not.toHaveBeenCalled();
+        });
+
+        it("calls a wildcard listener (streamId undefined) for any streamId", () => {
+            const onTrack = jest.fn();
+            registry.add({ streamRoomId: ROOM, onRemoteStreamTrack: onTrack });
+            registry.dispatchTrack(ROOM, makeTrackEvent(42));
+            expect(onTrack).toHaveBeenCalledTimes(1);
+        });
+
+        it("does not call listeners registered under a different room", () => {
+            const onTrack = jest.fn();
+            registry.add({ streamRoomId: ROOM_2, onRemoteStreamTrack: onTrack });
+            registry.dispatchTrack(ROOM, makeTrackEvent(1));
+            expect(onTrack).not.toHaveBeenCalled();
+        });
+
+        it("is a no-op when there are no listeners for the room", () => {
+            expect(() => registry.dispatchTrack(ROOM, makeTrackEvent(1))).not.toThrow();
+        });
+
+        it("skips listeners that have no onRemoteStreamTrack handler", () => {
+            registry.add({ streamRoomId: ROOM, streamId: sid(1) });
+            expect(() => registry.dispatchTrack(ROOM, makeTrackEvent(1))).not.toThrow();
+        });
+
+        it("calls both a specific and a wildcard listener when event matches", () => {
+            const specific = jest.fn();
+            const wildcard = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(5), onRemoteStreamTrack: specific });
+            registry.add({ streamRoomId: ROOM, onRemoteStreamTrack: wildcard });
+            registry.dispatchTrack(ROOM, makeTrackEvent(5));
+            expect(specific).toHaveBeenCalledTimes(1);
+            expect(wildcard).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("dispatchData", () => {
+        it("calls onRemoteData on matching listener", () => {
+            const onData = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(7), onRemoteData: onData });
+            const data = new Uint8Array([1, 2, 3]);
+            registry.dispatchData(ROOM, 7, data, 0);
+            expect(onData).toHaveBeenCalledWith(data, 0);
+        });
+
+        it("does not call listener for a different streamId", () => {
+            const onData = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(7), onRemoteData: onData });
+            registry.dispatchData(ROOM, 99, new Uint8Array(), 0);
+            expect(onData).not.toHaveBeenCalled();
+        });
+
+        it("calls wildcard listener for any streamId", () => {
+            const onData = jest.fn();
+            registry.add({ streamRoomId: ROOM, onRemoteData: onData });
+            registry.dispatchData(ROOM, 55, new Uint8Array([9]), 1);
+            expect(onData).toHaveBeenCalledTimes(1);
+            expect(onData).toHaveBeenCalledWith(new Uint8Array([9]), 1);
+        });
+
+        it("forwards the statusCode unchanged", () => {
+            const onData = jest.fn();
+            registry.add({ streamRoomId: ROOM, streamId: sid(2), onRemoteData: onData });
+            registry.dispatchData(ROOM, 2, new Uint8Array(), 42);
+            expect(onData).toHaveBeenCalledWith(expect.any(Uint8Array), 42);
+        });
+
+        it("is a no-op when there are no listeners for the room", () => {
+            expect(() => registry.dispatchData(ROOM, 1, new Uint8Array(), 0)).not.toThrow();
+        });
+
+        it("does not call listeners in a different room", () => {
+            const onData = jest.fn();
+            registry.add({ streamRoomId: ROOM_2, streamId: sid(1), onRemoteData: onData });
+            registry.dispatchData(ROOM, 1, new Uint8Array(), 0);
+            expect(onData).not.toHaveBeenCalled();
+        });
+
+        it("skips listeners that have no onRemoteData handler", () => {
+            registry.add({ streamRoomId: ROOM, streamId: sid(1) });
+            expect(() => registry.dispatchData(ROOM, 1, new Uint8Array(), 0)).not.toThrow();
+        });
+    });
+});

--- a/src/webStreams/worker/worker.ts
+++ b/src/webStreams/worker/worker.ts
@@ -41,10 +41,14 @@ if ((self as unknown as { RTCTransformEvent: unknown }).RTCTransformEvent) {
             postError("onrtctransform: options is undefined");
             return;
         }
-
         const { operation, kind, id, publisherId } = options;
-        const context: TransformContext = { id, publisherId };
-        handleTransform(context, operation, kind, event.transformer.readable, event.transformer.writable);
+        handleTransform(
+            { id, publisherId },
+            operation,
+            kind ?? "video",
+            event.transformer.readable,
+            event.transformer.writable,
+        );
     };
 }
 


### PR DESCRIPTION
- KeyStore: add sessionPrefix (crypto.randomUUID) to prevent cross-session key ID collisions; resolveKeyId() maps external→internal; renamed getEncryptionExternalKeyId() strips prefix for wire format
- StreamApi: override destroyRefs() to call client.destroy() on disconnect
- StreamApi: tighten Map types, use EndpointTypes.StreamRoomId throughout
- BaseApi: remove unused BaseNative import
- EventQueue: initialise deferedPromise as null to prevent stale state
- ConnectionNative/EventQueueNative: remove now-dead stub newApi() overrides
- worker.ts: default kind to "video" when undefined
- Add tests: AudioManager, E2eeTransformManager, RemoteStreamListenerRegistry