### PR TITLE
refactor(service): tighten optional param signatures, make native fields private

### DIFF
--- a/src/service/CryptoApi.ts
+++ b/src/service/CryptoApi.ts
@@ -50,7 +50,7 @@ export class CryptoApi extends BaseApi {
      * @param {string} [randomSeed] optional string used as the base to generate the new key
      * @returns {string} generated ECC key in WIF format
      */
-    async generatePrivateKey(randomSeed?: string | undefined): Promise<string> {
+    async generatePrivateKey(randomSeed?: string): Promise<string> {
         return this.native.generatePrivateKey(this.servicePtr, [randomSeed]);
     }
 
@@ -59,7 +59,7 @@ export class CryptoApi extends BaseApi {
      *
      * @param {string} password the password used to generate the new key
      * @param {string} salt random string (additional input for the hashing function)
-  
+     
      * @returns {string} generated ECC key in WIF format
      */
     async derivePrivateKey(password: string, salt: string): Promise<string> {
@@ -71,7 +71,7 @@ export class CryptoApi extends BaseApi {
      *
      * @param {string} password the password used to generate the new key
      * @param {string} salt random string (additional input for the hashing function)
-  
+     
      * @returns {string} generated ECC key in WIF format
      */
     async derivePrivateKey2(password: string, salt: string): Promise<string> {

--- a/src/service/InboxApi.ts
+++ b/src/service/InboxApi.ts
@@ -161,7 +161,7 @@ export class InboxApi extends BaseApi {
         inboxId: string,
         data: Uint8Array,
         inboxFileHandles: number[],
-        userPrivKey?: string | undefined,
+        userPrivKey?: string,
     ): Promise<number> {
         return this.native.prepareEntry(this.servicePtr, [
             inboxId,

--- a/src/service/KvdbApi.ts
+++ b/src/service/KvdbApi.ts
@@ -25,7 +25,7 @@ import {
 
 export class KvdbApi extends BaseApi {
     constructor(
-        protected native: KvdbApiNative,
+        private native: KvdbApiNative,
         ptr: number,
     ) {
         super(ptr);

--- a/src/service/ThreadApi.ts
+++ b/src/service/ThreadApi.ts
@@ -24,7 +24,7 @@ import {
 
 export class ThreadApi extends BaseApi {
     constructor(
-        protected native: ThreadApiNative,
+        private native: ThreadApiNative,
         ptr: number,
     ) {
         super(ptr);


### PR DESCRIPTION
Remove redundant `| undefined` from optional parameters in CryptoApi and InboxApi; tighten ThreadApi and KvdbApi native fields from protected to private to prevent accidental subclass access.